### PR TITLE
ci: :construction_worker: schedule Dependabot run time

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+      time: "11:25" # UTC
     groups:
       remix:
         patterns:


### PR DESCRIPTION
Schedule Dependabot to run at the same time each day, for consistency.