### PR TITLE
Make playwright tests use actual deployments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,9 @@
 name: Playwright Tests
 on:
-  - push
-  - pull_request
+    deployment_status:
 jobs:
   test:
+    if: github.event_name == 'deployment_status' && github.event.deployment_status.state == 'success'
     timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
@@ -17,6 +17,8 @@ jobs:
       run: npx playwright install --with-deps
     - name: Run Playwright tests
       run: npx playwright test
+      env:
+        DEPLOYMENT_URL: ${{ github.event.deployment_status.environment_url }}
     - uses: actions/upload-artifact@v4
       if: always()
       with:

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -24,7 +24,7 @@ export default defineConfig({
     /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
     use: {
         /* Base URL to use in actions like `await page.goto('/')`. */
-        baseURL: 'http://127.0.0.1:3000',
+        baseURL: process.env.CI ? process.env.DEPLOYMENT_URL : 'http://127.0.0.1:3000',
 
         /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
         trace: 'on-first-retry',
@@ -69,9 +69,11 @@ export default defineConfig({
     ],
 
     /* Run your local dev server before starting the tests */
-    webServer: {
-        command: 'npm run dev',
-        url: 'http://127.0.0.1:3000',
-        reuseExistingServer: !process.env.CI,
+    ...(!process.env.CI) && {
+        webServer: {
+            command: 'npm run dev',
+            url: 'http://127.0.0.1:3000',
+            reuseExistingServer: !process.env.CI,
+        }
     },
 });


### PR DESCRIPTION
Make the playwright tests use the actual Vercel previews, because some things are specific to Vercel.