### PR TITLE
perf: :zap: add prefetch to high-traffic nav links

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -50,8 +50,8 @@ export default function App() {
             <nav>
                 <ul>
                     <li><NavLink to="/">Home</NavLink></li>
-                    <li><NavLink to="/my-schedule/">Your Schedule</NavLink></li>
-                    <li><NavLink to="/events/">All Events</NavLink></li>
+                    <li><NavLink to="/my-schedule/" prefetch="intent">Your Schedule</NavLink></li>
+                    <li><NavLink to="/events/" prefetch="intent">All Events</NavLink></li>
                     <li><NavLink to="/settings/">Settings</NavLink></li>
                 </ul>
             </nav>


### PR DESCRIPTION
Set prefetch="intent" on the "Your Schedule" and "All Events" navigation links, so Remix will preload them on hover.