### PR TITLE
ci: :construction_worker: group all dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,12 +7,15 @@ updates:
       interval: "daily"
       time: "11:25" # UTC
     groups:
-      remix:
+      all:
         patterns:
-          - "@remix-run/*"
-      react:
-        patterns:
-          - "react"
-          - "react-dom"
-          - "@types/react"
-          - "@types/react-dom"
+          - "*"
+    #   remix:
+    #     patterns:
+    #       - "@remix-run/*"
+    #   react:
+    #     patterns:
+    #       - "react"
+    #       - "react-dom"
+    #       - "@types/react"
+    #       - "@types/react-dom"


### PR DESCRIPTION
Make dependabot put all its dependency bumps in one PR. This is faster and simpler, and we can always go back to using smaller groups if it becomes an issue.