### PR TITLE
fix(database): :card_file_box: mark some fields as unique

### DIFF
--- a/prisma/migrations/20240320225600_unique_fix/migration.sql
+++ b/prisma/migrations/20240320225600_unique_fix/migration.sql
@@ -1,0 +1,12 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[name]` on the table `Role` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[username]` on the table `User` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE UNIQUE INDEX "Role_name_key" ON "Role"("name");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_username_key" ON "User"("username");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -12,7 +12,7 @@ datasource db {
 
 model User {
     id             Int                 @id @default(autoincrement())
-    username       String
+    username       String              @unique
     approvedRoles  Role[]              @relation("roleMember")
     managingRoles  Role[]              @relation("roleManager")
     permissionSets UserPermissionSet[]
@@ -33,7 +33,7 @@ enum UserPermissionSet {
 
 model Role {
     id            Int        @id @default(autoincrement())
-    name          String /// For URLs etc.
+    name          String     @unique /// For URLs etc.
     displayName   String
     approvedUsers User[]     @relation("roleMember")
     managers      User[]     @relation("roleManager")


### PR DESCRIPTION
Require some identifier fields that aren't technically IDs (`@id`<!--sorry for the accidental mention!-->) to be unique in the Prisma schema.

This is not a breaking change because we don't use the database in the app yet.